### PR TITLE
SYMP-29 | removed spanish from locales, language selector

### DIFF
--- a/apps/web/public/locales/es/translation.json
+++ b/apps/web/public/locales/es/translation.json
@@ -1,9 +1,0 @@
-{
-  "AppName": "COVID-19 Self-Assessment Tool",
-  "Welcome": "Bienvenido",
-  "Question": "Pregunta",
-  "Go back": "Regresa",
-  "Continue": "Continuar",
-  "Result": "Resultado",
-  "Start assessment": "Iniciar evaluación"
-}

--- a/apps/web/src/components/LanguageSelector.tsx
+++ b/apps/web/src/components/LanguageSelector.tsx
@@ -10,7 +10,6 @@ import globe from 'src/images/globe.svg';
 const languages = {
   en: 'English',
   fr: 'Français',
-  es: 'Español',
   zh: '中文(繁體)',
   pa: 'ਪੰਜਾਬੀ',
 };

--- a/apps/web/src/forms/Q4TestResult.tsx
+++ b/apps/web/src/forms/Q4TestResult.tsx
@@ -10,7 +10,7 @@ import { Tooltip } from '../components/Tooltip';
 import calendar from '../images/calendar.svg';
 import upendCaret from '../images/upend-caret.svg';
 
-import { enCA as en, frCA as fr, zhCN as zh, faIR as fa, es } from 'date-fns/locale';
+import { enCA as en, frCA as fr, zhCN as zh, faIR as fa } from 'date-fns/locale';
 import { Field, useFormikContext } from 'formik';
 import RadioButtons from 'src/components/RadioButtons';
 import { ErrorBox } from '../components/ErrorBox';
@@ -18,7 +18,6 @@ import _ from 'lodash';
 
 registerLocale('en', en);
 registerLocale('fr', fr);
-registerLocale('es', es);
 registerLocale('zh', zh);
 registerLocale('pa', fa);
 


### PR DESCRIPTION
Ticket: https://freshworks.atlassian.net/browse/SYMP-29

Added Spanish before in error, taking it out