### PR TITLE
Adding response cloudfront function

### DIFF
--- a/apps/web/public/index.html
+++ b/apps/web/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -23,6 +23,14 @@ resource "aws_cloudfront_function" "response" {
   code     = file("${path.module}/cloudfront/response.js")
 }
 
+resource "aws_cloudfront_function" "request" {
+  provider = aws.us-east-1
+  name     = "${local.namespace}-cf-request"
+  runtime  = "cloudfront-js-1.0"
+  comment  = "Redirect to index for sitemap.xml"
+  code     = file("${path.module}/cloudfront/request.js")
+}
+
 resource "aws_cloudfront_distribution" "app" {
   comment = local.app_name
   aliases = var.target_env == "prod" ? [] : ["${var.target_env}.symchk.freshworks.club"]
@@ -83,6 +91,10 @@ resource "aws_cloudfront_distribution" "app" {
     function_association {
       event_type   = "viewer-response"
       function_arn = aws_cloudfront_function.response.arn
+    }
+        function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.request.arn
     }
   }
 

--- a/terraform/cloudfront/request.js
+++ b/terraform/cloudfront/request.js
@@ -1,0 +1,12 @@
+// Next.js request handler
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  if (uri.match(/sitemap.xml/)) {
+    request.uri = uri.replace(/sitemap.xml/, 'index.html');
+    return request;
+  }
+
+  return request;
+}


### PR DESCRIPTION
Fixed two more CSP warnings - Switched icon192.png for favicon.ico and added a redirect for sitemap.xml to hit index.html instead. The only remaining issues are the wildcard flags on the CSP.
<img width="1678" alt="Screen Shot 2022-06-17 at 12 44 10 PM" src="https://user-images.githubusercontent.com/54554766/174391695-6e512a0d-3e68-412f-8e4c-5cac4baaf227.png">

