### PR TITLE
SYMP-57

### DIFF
--- a/apps/web/src/components/LanguageSelector.tsx
+++ b/apps/web/src/components/LanguageSelector.tsx
@@ -10,7 +10,7 @@ import globe from 'src/images/globe.svg';
 const languages = {
   en: 'English',
   fr: 'Français',
-  zh: '中文(繁體)',
+  zh: '中文',
   pa: 'ਪੰਜਾਬੀ',
 };
 


### PR DESCRIPTION
 Removed (繁體) from the language select, as it is misleading
 
 繁體 - translates to traditional. Unless we are planning on supporting traditional Mandarin, we should remove it. 
 
 This also solves SYMP-57, the extra characters were causing a newline in the element. 
 If we do end up supporting both traditional and simplified, I can switch this back. 
<img width="407" alt="Screen Shot 2022-06-17 at 3 56 23 PM" src="https://user-images.githubusercontent.com/54554766/174410570-39194ac7-80e1-4850-afac-388e583bbf7c.png">

