### PR TITLE
SYMP-72 | Disable language selection

### DIFF
--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -13,7 +13,7 @@ i18n
       order: ['path', 'navigator', 'querystring', 'cookie'],
     },
     debug: true,
-    supportedLngs: ['en', 'fr', 'es', 'pa', 'zh'],
+    supportedLngs: ['en'], //available: ['en', 'fr', 'pa', 'zh']
     preload: ['en', 'fr'],
     ns: ['translation', 'symptoms'],
     interpolation: {


### PR DESCRIPTION
Ticket: https://freshworks.atlassian.net/browse/SYMP-72

Made English the only supported language for now to disable automatic language selection. I left the planned languages commented out on the same line to keep it easier to revert later